### PR TITLE
[FIX] Empty path is valid

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,13 +49,8 @@ func main() {
 
 func processFlags() error {
 	flag.Parse()
-	if source == "" {
-		flag.Usage()
-		return fmt.Errorf("source directory is required")
-	}
-	if target == "" {
-		flag.Usage()
-		return fmt.Errorf("target directory is required")
+	if source == target {
+		return fmt.Errorf("source & target must be different")
 	}
 	stat, err := os.Stat(source)
 	if err != nil {


### PR DESCRIPTION
Package os derives the current working directory from an empty string. However, the source and target directories must not be identical.